### PR TITLE
Public menu

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,6 +12,7 @@ import ForgotPasswordScreen from "./screens/ForgotPasswordScreen";
 import ResetPasswordScreen from "./screens/ResetPasswordScreen";
 import NewsPage from "./screens/NewsPage";
 import PetProfile from "./screens/PetProfile";
+import MenuPublicScreen from "./screens/MenuPublicScreen";
 
 
 const styles = StyleSheet.create({
@@ -23,54 +24,55 @@ const styles = StyleSheet.create({
   },
 });
 
-const Stack = createNativeStackNavigator();
+// const Stack = createNativeStackNavigator();
 
 function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator initialRouteName="Home">
-      <Stack.Screen
-        name="Home"
-        component={HomeScreen}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name="CreateAccount"
-        component={CreateAccountScreen}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name="Login"
-        component={LoginScreen}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name="ForgotPassword"
-        component={ForgotPasswordScreen}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name="ResetPassword"
-        component={ResetPasswordScreen}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name="AddPet"
-        component={AddPet}
-        options={{ headerShown: false }}
-      />
-       <Stack.Screen
-        name="PetProfile"
-        component={PetProfile}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-          name="NewsPage"
-          component={NewsPage}
-          options={{ headerShown: false }}
-      />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <MenuPublicScreen />
+    // <NavigationContainer>
+    //   <Stack.Navigator initialRouteName="Home">
+    //   <Stack.Screen
+    //     name="Home"
+    //     component={HomeScreen}
+    //     options={{ headerShown: false }}
+    //   />
+    //   <Stack.Screen
+    //     name="CreateAccount"
+    //     component={CreateAccountScreen}
+    //     options={{ headerShown: false }}
+    //   />
+    //   <Stack.Screen
+    //     name="Login"
+    //     component={LoginScreen}
+    //     options={{ headerShown: false }}
+    //   />
+    //   <Stack.Screen
+    //     name="ForgotPassword"
+    //     component={ForgotPasswordScreen}
+    //     options={{ headerShown: false }}
+    //   />
+    //   <Stack.Screen
+    //     name="ResetPassword"
+    //     component={ResetPasswordScreen}
+    //     options={{ headerShown: false }}
+    //   />
+    //   <Stack.Screen
+    //     name="AddPet"
+    //     component={AddPet}
+    //     options={{ headerShown: false }}
+    //   />
+    //    <Stack.Screen
+    //     name="PetProfile"
+    //     component={PetProfile}
+    //     options={{ headerShown: false }}
+    //   />
+    //   <Stack.Screen
+    //       name="NewsPage"
+    //       component={NewsPage}
+    //       options={{ headerShown: false }}
+    //   />
+    //   </Stack.Navigator>
+    // </NavigationContainer>
   );
 }
 

--- a/App.js
+++ b/App.js
@@ -46,7 +46,8 @@ const NewsPageNavigator = () => (
 const HomeNavigator = () => (
   <Stack.Navigator
     screenOptions={{
-      headerShown: false
+      headerBackButtonMenuEnabled: true, 
+      headerTitle: ""
     }}
   >
     <Stack.Screen
@@ -79,7 +80,8 @@ const HomeNavigator = () => (
 const AccountNavigator = () => (
   <Stack.Navigator
     screenOptions={{
-      headerShown: false
+      headerBackButtonMenuEnabled: true,
+      headerTitle: ""
     }}
   >
     <Stack.Screen

--- a/App.js
+++ b/App.js
@@ -3,6 +3,8 @@ import { StatusBar } from "expo-status-bar";
 import { StyleSheet, Text, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"; 
+import { MaterialCommunityIcons } from "@expo/vector-icons"; 
 
 import HomeScreen from "./screens/HomeScreen";
 import CreateAccountScreen from "./screens/CreateAccountScreen";
@@ -13,6 +15,7 @@ import ResetPasswordScreen from "./screens/ResetPasswordScreen";
 import NewsPage from "./screens/NewsPage";
 import PetProfile from "./screens/PetProfile";
 import MenuPublicScreen from "./screens/MenuPublicScreen";
+import colors from "./config/colors";
 
 
 const styles = StyleSheet.create({
@@ -25,10 +28,37 @@ const styles = StyleSheet.create({
 });
 
 // const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator(); 
+const TabNavigator = () => (
+  <Tab.Navigator
+    screenOptions={{
+      tabBarActiveBackgroundColor: colors.lightgray, 
+      tabBarActiveTintColor: colors.black
+    }}
+  >
+    <Tab.Screen 
+      name="News Feed" 
+      component={NewsPage}
+      options={{ tabBarIcon: ({ size }) => <MaterialCommunityIcons name="newspaper" size={size} />}}
+    />
+    <Tab.Screen 
+      name="Home" 
+      component={HomeScreen} 
+      options={{ tabBarIcon: ({ size }) => <MaterialCommunityIcons name="home" size={size} />}}
+    />
+    <Tab.Screen 
+      name="Account"  
+      component={MenuPublicScreen}
+      options={{ tabBarIcon: ({ size }) => <MaterialCommunityIcons name="account" size={size} />}}
+    />
+  </Tab.Navigator>
+)
 
 function App() {
   return (
-    <MenuPublicScreen />
+    <NavigationContainer>
+      <TabNavigator />
+    </NavigationContainer>
     // <NavigationContainer>
     //   <Stack.Navigator initialRouteName="Home">
     //   <Stack.Screen

--- a/App.js
+++ b/App.js
@@ -27,28 +27,94 @@ const styles = StyleSheet.create({
   },
 });
 
-// const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator();
+
+const NewsPageNavigator = () => (
+  <Stack.Navigator
+    screenOptions={{
+      headerShown: false
+    }}
+  >
+    <Stack.Screen
+      name="NewsPage"
+      component={NewsPage}
+      options={{ headerShown: false }}
+    />
+  </Stack.Navigator>
+)
+
+const HomeNavigator = () => (
+  <Stack.Navigator
+    screenOptions={{
+      headerShown: false
+    }}
+  >
+    <Stack.Screen
+      name="HomeStack"
+      component={HomeScreen}
+    />
+    <Stack.Screen
+      name="CreateAccount"
+      component={CreateAccountScreen}
+    />
+    <Stack.Screen
+      name="Login"
+      component={LoginScreen}
+    />
+    <Stack.Screen
+      name="ForgotPassword"
+      component={ForgotPasswordScreen}
+    />
+    <Stack.Screen
+      name="ResetPassword"
+      component={ResetPasswordScreen}
+    /> 
+    <Stack.Screen
+      name="AddPet"
+      component={AddPet}
+    />
+  </Stack.Navigator>
+)
+
+const AccountNavigator = () => (
+  <Stack.Navigator
+    screenOptions={{
+      headerShown: false
+    }}
+  >
+    <Stack.Screen
+      name="MenuPublic"
+      component={MenuPublicScreen}
+    />  
+    <Stack.Screen
+      name="PetProfile"
+      component={PetProfile}
+    /> 
+  </Stack.Navigator>
+)
+
 const Tab = createBottomTabNavigator(); 
 const TabNavigator = () => (
   <Tab.Navigator
     screenOptions={{
       tabBarActiveBackgroundColor: colors.lightgray, 
-      tabBarActiveTintColor: colors.black
+      tabBarActiveTintColor: colors.black, 
+      headerShown: false
     }}
   >
     <Tab.Screen 
       name="News Feed" 
-      component={NewsPage}
+      component={NewsPageNavigator}
       options={{ tabBarIcon: ({ size }) => <MaterialCommunityIcons name="newspaper" size={size} />}}
     />
     <Tab.Screen 
       name="Home" 
-      component={HomeScreen} 
+      component={HomeNavigator} 
       options={{ tabBarIcon: ({ size }) => <MaterialCommunityIcons name="home" size={size} />}}
     />
     <Tab.Screen 
       name="Account"  
-      component={MenuPublicScreen}
+      component={AccountNavigator}
       options={{ tabBarIcon: ({ size }) => <MaterialCommunityIcons name="account" size={size} />}}
     />
   </Tab.Navigator>
@@ -59,50 +125,6 @@ function App() {
     <NavigationContainer>
       <TabNavigator />
     </NavigationContainer>
-    // <NavigationContainer>
-    //   <Stack.Navigator initialRouteName="Home">
-    //   <Stack.Screen
-    //     name="Home"
-    //     component={HomeScreen}
-    //     options={{ headerShown: false }}
-    //   />
-    //   <Stack.Screen
-    //     name="CreateAccount"
-    //     component={CreateAccountScreen}
-    //     options={{ headerShown: false }}
-    //   />
-    //   <Stack.Screen
-    //     name="Login"
-    //     component={LoginScreen}
-    //     options={{ headerShown: false }}
-    //   />
-    //   <Stack.Screen
-    //     name="ForgotPassword"
-    //     component={ForgotPasswordScreen}
-    //     options={{ headerShown: false }}
-    //   />
-    //   <Stack.Screen
-    //     name="ResetPassword"
-    //     component={ResetPasswordScreen}
-    //     options={{ headerShown: false }}
-    //   />
-    //   <Stack.Screen
-    //     name="AddPet"
-    //     component={AddPet}
-    //     options={{ headerShown: false }}
-    //   />
-    //    <Stack.Screen
-    //     name="PetProfile"
-    //     component={PetProfile}
-    //     options={{ headerShown: false }}
-    //   />
-    //   <Stack.Screen
-    //       name="NewsPage"
-    //       component={NewsPage}
-    //       options={{ headerShown: false }}
-    //   />
-    //   </Stack.Navigator>
-    // </NavigationContainer>
   );
 }
 

--- a/components/MenuItem.js
+++ b/components/MenuItem.js
@@ -3,9 +3,9 @@ import { Text, TouchableHighlight, StyleSheet, View } from 'react-native';
 
 import colors from '../config/colors';
 
-function MenuItem({ IconComponent, title }) {
+function MenuItem({ IconComponent, onPress, title }) {
     return (
-        <TouchableHighlight>
+        <TouchableHighlight underlayColor={colors.lightgray} onPress={onPress}>
             <View style={styles.container}>
                 {IconComponent}
                 <View style={styles.detailsContainer}>

--- a/components/MenuItem.js
+++ b/components/MenuItem.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Text, TouchableHighlight, StyleSheet, View } from 'react-native';
+
+import colors from '../config/colors';
+
+function MenuItem({ title }) {
+    return (
+        <TouchableHighlight>
+            <View style={styles.container}>
+                <Text style={styles.text}>{ title }</Text>
+            </View>
+        </TouchableHighlight>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row", 
+        padding: 15, 
+        backgroundColor: colors.white
+    }, 
+    text: {
+        fontWeight: 500
+    }
+})
+
+export default MenuItem;

--- a/components/MenuItem.js
+++ b/components/MenuItem.js
@@ -3,11 +3,14 @@ import { Text, TouchableHighlight, StyleSheet, View } from 'react-native';
 
 import colors from '../config/colors';
 
-function MenuItem({ title }) {
+function MenuItem({ IconComponent, title }) {
     return (
         <TouchableHighlight>
             <View style={styles.container}>
-                <Text style={styles.text}>{ title }</Text>
+                {IconComponent}
+                <View style={styles.detailsContainer}>
+                    <Text style={styles.text}>{ title }</Text>
+                </View>
             </View>
         </TouchableHighlight>
     );
@@ -19,6 +22,10 @@ const styles = StyleSheet.create({
         padding: 15, 
         backgroundColor: colors.white
     }, 
+    detailsContainer: {
+        marginLeft: 15, 
+        justifyContent: "center"
+    },
     text: {
         fontWeight: 500
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-community/checkbox": "^0.5.17",
         "@react-native-community/masked-view": "^0.1.11",
         "@react-native-picker/picker": "^2.7.5",
+        "@react-navigation/bottom-tabs": "^6.5.20",
         "@react-navigation/drawer": "^6.6.15",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
@@ -6111,6 +6112,23 @@
       },
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "6.5.20",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.20.tgz",
+      "integrity": "sha512-ow6Z06iS4VqBO8d7FP+HsGjJLWt2xTWIvuWjpoCvsM/uQXzCRDIjBv9HaKcXbF0yTW7IMir0oDAbU5PFzEDdgA==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.30",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@react-navigation/core": {
@@ -19374,6 +19392,16 @@
       "requires": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
+      }
+    },
+    "@react-navigation/bottom-tabs": {
+      "version": "6.5.20",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.20.tgz",
+      "integrity": "sha512-ow6Z06iS4VqBO8d7FP+HsGjJLWt2xTWIvuWjpoCvsM/uQXzCRDIjBv9HaKcXbF0yTW7IMir0oDAbU5PFzEDdgA==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.30",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
       }
     },
     "@react-navigation/core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-native-community/checkbox": "^0.5.17",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-picker/picker": "^2.7.5",
+    "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/drawer": "^6.6.15",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -84,6 +84,7 @@ function MenuPublicScreen(props) {
             <View style={styles.separator} />
             <MenuItem 
                 title="Log Out"
+                onPress={() => console.log("Will later replace this with navigation too.")}
                 IconComponent={<Icon name="logout" backgroundColor={colors.lightgray} />}
             />
         </SafeScreen>

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -69,6 +69,7 @@ function MenuPublicScreen(props) {
                     renderItem={({ item }) => (
                         <MenuItem 
                             title={item.title}
+                            onPress={() => console.log("Will later replace this with navigation.")}
                             IconComponent={
                                 <Icon 
                                     name={item.icon.name}

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -80,6 +80,7 @@ function MenuPublicScreen(props) {
                     ItemSeparatorComponent={() => <View style={styles.separator} />}
                 />
             </View>
+            <View style={styles.separator} />
             <MenuItem 
                 title="Log Out"
                 IconComponent={<Icon name="logout" backgroundColor={colors.lightgray} />}

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -10,17 +10,52 @@ import colors from '../config/colors';
 function MenuPublicScreen(props) {
     const menuItems = [
         {
-            title: "Settings", 
+            title: "Dogs", 
             icon: {
-                name: "format-list-bulleted", 
+                name: "dog", 
+                backgroundColor: colors.mediumblue
+            }
+        },
+        {
+            title: "Cats", 
+            icon: {
+                name: "cat", 
+                backgroundColor: colors.mediumblue
+            }
+        },
+        {
+            title: "Other Animals", 
+            icon: {
+                name: "turtle", 
+                backgroundColor: colors.mediumblue
+            }
+        },
+        {
+            title: "Search", 
+            icon: {
+                name: "card-search", 
                 backgroundColor: colors.black
             }, 
             
         }, 
         {
-            title: "Stats", 
+            title: "Favorites", 
             icon: {
-                name: "chart-bar", 
+                name: "star", 
+                backgroundColor: colors.error
+            }
+        }, 
+        {
+            title: "Email Preferences", 
+            icon: {
+                name: "email", 
+                backgroundColor: colors.error
+            }
+        }, 
+        {
+            title: "Account Preferences", 
+            icon: {
+                name: "account", 
                 backgroundColor: colors.error
             }
         }

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import { FlatList, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
 import SafeScreen from '../components/SafeScreen'; 
 
@@ -29,7 +29,14 @@ function MenuPublicScreen(props) {
                 <FlatList 
                     data={menuItems}
                     keyExtractor={(menuItems) => menuItems.title}
-                    ItemSeparatorComponent={styles.separator}
+                    renderItem={({ item }) => (
+                        <TouchableHighlight>
+                            <View>
+                                <Text>{ item.title }</Text>
+                            </View>
+                        </TouchableHighlight>
+                    )}
+                    ItemSeparatorComponent={() => <View style={styles.separator} />}
                 />
             </View>
         </SafeScreen>

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FlatList, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
+import MenuItem from '../components/MenuItem';
 import SafeScreen from '../components/SafeScreen'; 
 
 import colors from '../config/colors'; 
@@ -30,11 +31,9 @@ function MenuPublicScreen(props) {
                     data={menuItems}
                     keyExtractor={(menuItems) => menuItems.title}
                     renderItem={({ item }) => (
-                        <TouchableHighlight>
-                            <View>
-                                <Text>{ item.title }</Text>
-                            </View>
-                        </TouchableHighlight>
+                        <MenuItem 
+                            title={item.title}
+                        />
                     )}
                     ItemSeparatorComponent={() => <View style={styles.separator} />}
                 />

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -80,6 +80,10 @@ function MenuPublicScreen(props) {
                     ItemSeparatorComponent={() => <View style={styles.separator} />}
                 />
             </View>
+            <MenuItem 
+                title="Log Out"
+                IconComponent={<Icon name="logout" backgroundColor={colors.lightgray} />}
+            />
         </SafeScreen>
     );
 }

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -3,6 +3,7 @@ import { FlatList, StyleSheet, Text, TouchableHighlight, View } from 'react-nati
 
 import MenuItem from '../components/MenuItem';
 import SafeScreen from '../components/SafeScreen'; 
+import Icon from '../components/Icon';
 
 import colors from '../config/colors'; 
 
@@ -19,7 +20,7 @@ function MenuPublicScreen(props) {
         {
             title: "Stats", 
             icon: {
-                name: "char-bar", 
+                name: "chart-bar", 
                 backgroundColor: colors.error
             }
         }
@@ -33,6 +34,12 @@ function MenuPublicScreen(props) {
                     renderItem={({ item }) => (
                         <MenuItem 
                             title={item.title}
+                            IconComponent={
+                                <Icon 
+                                    name={item.icon.name}
+                                    backgroundColor={item.icon.backgroundColor}
+                                />
+                            }
                         />
                     )}
                     ItemSeparatorComponent={() => <View style={styles.separator} />}

--- a/screens/MenuPublicScreen.js
+++ b/screens/MenuPublicScreen.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { FlatList, StyleSheet, View } from 'react-native';
+
+import SafeScreen from '../components/SafeScreen'; 
+
+import colors from '../config/colors'; 
+
+function MenuPublicScreen(props) {
+    const menuItems = [
+        {
+            title: "Settings", 
+            icon: {
+                name: "format-list-bulleted", 
+                backgroundColor: colors.black
+            }, 
+            
+        }, 
+        {
+            title: "Stats", 
+            icon: {
+                name: "char-bar", 
+                backgroundColor: colors.error
+            }
+        }
+    ]
+    return (
+        <SafeScreen> 
+            <View style={styles.container}>
+                <FlatList 
+                    data={menuItems}
+                    keyExtractor={(menuItems) => menuItems.title}
+                    ItemSeparatorComponent={styles.separator}
+                />
+            </View>
+        </SafeScreen>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        
+    }, 
+    separator: {
+        width: "100%", 
+        height: 1,
+        backgroundColor: colors.lightgray
+    }
+})
+
+export default MenuPublicScreen;


### PR DESCRIPTION
I added a Tabs Navigation and separated the Stack Navigation accordingly. I set up on the Stack Navigations so that the back button is displaying on the header whenever you navigate away from the Tab Screens. I added an Account Tab, so that the menu for public accounts are displayed.  In result of this, the hamburger icon on the News Page and Home Page can be deleted in the future, as well as the coded back buttons on the News Page and Add Pet. 

For the public menu, each named item should have their respective icons and is press-able. Will add on navigation after correlating screens are created. 

Keeping the Add Pet button on the Home screen for now until the Admin menu is made. 